### PR TITLE
added probably pretty buggy infix math parser

### DIFF
--- a/math_parser.py
+++ b/math_parser.py
@@ -1,0 +1,91 @@
+import math
+
+
+EMDAS = {
+    '+' : lambda a, b: lambda s: a(s) + b(s),
+    '-' : lambda a, b: lambda s: a(s) - b(s),
+    '*' : lambda a, b: lambda s: a(s) * b(s),
+    '/' : lambda a, b: lambda s: a(s) / b(s),
+    '**': lambda a, b: lambda s: a(s) ** b(s),
+}
+
+
+SCOPE = {
+    'sin': lambda args: math.sin(args[0]),
+    'cos': lambda args: math.cos(args[0]),
+    'max': lambda args: max(args),
+    'min': lambda args: min(args),
+    'abs': lambda args: abs(args[0]),
+    'pi' : math.pi,
+}
+
+
+def badfix(string):
+    string = string.replace(',', ' ')
+    for op in EMDAS:
+        string = string.replace(op, ' ' + op + ' ')
+    return string
+
+def descend(tree, depth):
+    if depth == 0:
+        return tree
+    if not isinstance(tree[-1], list):
+        tree.append([])
+    return descend(tree[-1], depth - 1)
+
+
+def paren(string):
+    split = [[y.strip() for y in x.split(')')] for x in string.split('(')]
+    tree = [x for x in split[0][0].split(' ') if x]
+    depth = 0
+    for s in split[1:]:
+        node = descend(tree, depth)
+        node.append([x for x in s[0].split(' ') if x])
+        depth += 1
+        for n in s[1:]:
+            depth -= 1
+            if len(n) > 0:
+                node = descend(tree, depth)
+                node += [x for x in n.split(' ') if x]
+    if depth != 0:
+        print('Warning: malformed expression:')
+        print(string)
+    return tree
+
+
+def expression(tree):
+    if not isinstance(tree, list):
+        try:
+            f = float(tree)
+            return lambda s: f
+        except:
+            n = tree
+            return lambda s: s[n]
+    if len(tree) == 1:
+        return expression(tree[0])
+    if len(tree) == 2:
+        f = expression(tree[0])
+        args = [expression(arg) for arg in tree[1]]
+        return lambda s: f(s)([arg(s) for arg in args])
+    for op in EMDAS.keys():
+        if op in tree:
+            i = tree.index(op)
+            l = tree[:i]
+            r = tree[i+1:]
+
+            return EMDAS[op](
+                expression(l),
+                expression(r),
+            )
+    print('Warning: malformed expression:')
+    print(tree)
+    return lambda s: None
+
+
+def pythonify(string):
+    expr = expression(paren(badfix(string)))
+    def evaluate(**kwargs):
+        scope = dict(SCOPE)
+        scope.update(kwargs)
+        return expr(scope)
+    return evaluate

--- a/math_parser.py
+++ b/math_parser.py
@@ -63,20 +63,24 @@ def expression(tree):
             return lambda s: s[n]
     if len(tree) == 1:
         return expression(tree[0])
-    if len(tree) == 2:
-        f = expression(tree[0])
-        args = [expression(arg) for arg in tree[1]]
-        return lambda s: f(s)([arg(s) for arg in args])
     for op in EMDAS.keys():
         if op in tree:
             i = tree.index(op)
             l = tree[:i]
             r = tree[i+1:]
 
+            if l == [] and op == '-':
+                r = expression(r)
+                return lambda s: -1 * r(s)
+
             return EMDAS[op](
                 expression(l),
                 expression(r),
             )
+    if len(tree) == 2:
+        f = expression(tree[0])
+        args = [expression(arg) for arg in tree[1]]
+        return lambda s: f(s)([arg(s) for arg in args])
     print('Warning: malformed expression:')
     print(tree)
     return lambda s: None

--- a/math_parser.py
+++ b/math_parser.py
@@ -20,6 +20,10 @@ SCOPE = {
 }
 
 
+class MalformedException(Exception):
+    pass
+
+
 def badfix(string):
     string = string.replace(',', ' ')
     for op in EMDAS:
@@ -48,8 +52,7 @@ def paren(string):
                 node = descend(tree, depth)
                 node += [x for x in n.split(' ') if x]
     if depth != 0:
-        print('Warning: malformed expression:')
-        print(string)
+        raise MalformedException('Unmatched parenthesis in expression', string)
     return tree
 
 
@@ -81,8 +84,7 @@ def expression(tree):
         f = expression(tree[0])
         args = [expression(arg) for arg in tree[1]]
         return lambda s: f(s)([arg(s) for arg in args])
-    print('Warning: malformed expression:')
-    print(tree)
+    raise MalformedException('Unable to parse expression', tree)
     return lambda s: None
 
 


### PR DESCRIPTION
Did pretty minimal manual testing. Didn't bother replacing existing prefix notation parser because that would require updating level files. I think it supports everything that needed to be supported function/constant/variable wise, but if not, should be pretty easy to add new stuff. Seriously jank way of approaching the tree.

Usage:

```
f = math_parser.pythonify('2 * pi * t')
f(t = 10)
```

```
> 62.83185307179586
```

Supports multivariate expressions.
